### PR TITLE
Add worker yaml

### DIFF
--- a/manifests/daemonset-sriov-device-plugin.yaml
+++ b/manifests/daemonset-sriov-device-plugin.yaml
@@ -11,7 +11,7 @@ data:
                 "resourceName": "mlnx_bf",
                 "selectors": {
                     "vendors": ["15b3"],
-                    "devices": ["a2d3", "101e"],
+                    "devices": ["a2d6", "a2d3", "101e"],
                     "pfNames": ["ens1f0#1-3"] # exclude vf0 (ovn mgmt port on host)
                 }
             }

--- a/manifests/worker.yaml
+++ b/manifests/worker.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openshift-${worker-name}-bmc-secret
+  namespace: openshift-machine-api
+type: Opaque
+data:
+  username: cm9vdA==
+  password: Y2Fsdmlu
+
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: ${worker-name}
+  namespace: openshift-machine-api
+spec:
+  online: true
+  bmc:
+    address: ipmi://${worker-bmc-ipaddr}
+    credentialsName: openshift-${worker-name}-bmc-secret
+  bootMACAddress: ${worker-iface-mac-sriovpr}
+


### PR DESCRIPTION
Add sample worker.yaml file to create a BareMetalHost worker. Also add new Device ID to SR-IOV ConfigMap for BF-2.