### PR TITLE
Remove comment in config map that breaks creating ConfigMap for sriov device plugin

### DIFF
--- a/manifests/daemonset-sriov-device-plugin.yaml
+++ b/manifests/daemonset-sriov-device-plugin.yaml
@@ -12,7 +12,7 @@ data:
                 "selectors": {
                     "vendors": ["15b3"],
                     "devices": ["101e"],
-                    "pfNames": ["ens1f0#1-3"] # exclude vf0 (ovn mgmt port on host)
+                    "pfNames": ["ens1f0#1-3"]
                 }
             }
         ]


### PR DESCRIPTION
Signed-off-by: Balazs Nemeth <bnemeth@redhat.com>